### PR TITLE
Fix a feed loading error on some pages.

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -64,9 +64,15 @@ export class Entry {
         } else if (dom.description) {
             if (isString(dom.description)) {
                 content = dom.description;
-            } else if (dom.description.text) {
+            } else if (isString(dom.description.text)) {
                 content = dom.description.text;
+            } else if (isString(dom.description.__cdata)) {
+                content = dom.description.__cdata;
             }
+        } else if (isString(dom.summary)) {
+            content = dom.summary;
+        } else if (isString(dom.summary.text)) {
+            content = dom.summary.text;
         }
         if (!isString(content)) {
             throw new Error("Feed Format Error: Entry Missing Content");
@@ -96,6 +102,8 @@ export class Entry {
             date = dom.pubDate;
         } else if (dom.updated) {
             date = dom.updated;
+        } else if (dom["dc:date"]) {
+            date = dom["dc:date"];
         }
         if (!isString(date)) {
             throw new Error("Feed Format Error: Entry Missing Date");
@@ -130,7 +138,8 @@ export class Content {
             attrNodeName: "attr",
             textNodeName: "text",
             ignoreAttributes: false,
-            parseAttributeValue: true
+            parseAttributeValue: true,
+            cdataTagName: "__cdata"
         });
         let feed;
         if (dom.rss) {
@@ -154,9 +163,11 @@ export class Content {
         if (feed.title) {
             if (isString(feed.title)) {
                 title = feed.title;
-            } else if (feed.title.text) {
+            } else if (isString(feed.title.text)) {
                 title = feed.title.text;
             }
+        } else if (feed.channel.title) {
+            title = feed.channel.title;
         }
         if (!isString(title)) {
             throw new Error('Feed Format Error: Missing Title');
@@ -166,6 +177,8 @@ export class Content {
         let link: any;
         if (feed.link) {
             link = parseLink(feed.link);
+        } else if (feed.channel.link) {
+            link = parseLink(feed.channel.link);
         }
         if (!isString(link)) {
             throw new Error('Feed Format Error: Missing Link');


### PR DESCRIPTION
The following pages have a feed of the following structure.

https: //rss.itmedia.co.jp/rss/1.0/pcuser.xml
https: //www.4gamer.net/words/000/W00064/contents.xml

```
<rdf:RDF>
  <channel>
    <title />
    <link />
  </channel>
  <item />
</rdf:RDF>
```

So I've added the `feed.channel.title` and `feed.channel.link` to
check for them.

Also, the date of the individual item was the tag `<dc:date>`.
Added confirmation of `<dc:date>` when getting data.

The next feed is surrounded by `<![CDATA[`~`]]>` in the description.

https: //forest.watch.impress.co.jp/data/rss/1.0/wf/feed.rdf

I added `cdataTagName: "__cdata"` option to fast-xml-parser to parse
`<![CDATA[`~`]]>`.

The next feed is `entry` with a `summary` instead of a `content` or
a `description`.

https://blog.jxck.io/feeds/atom.xml
https://enginetrouble.net/feeds/all.atom.xml

summary is now read as content.