### PR TITLE
Make the domain of Inoreader configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
                     "type": "string",
                     "default": null,
                     "description": "Data storage path"
+                },
+                "rss.inoreader-domain": {
+                    "type": "string",
+                    "default": "www.inoreader.com",
+                    "description": "Domain of Inoreader"
                 }
             }
         },

--- a/src/inoreader_collection.ts
+++ b/src/inoreader_collection.ts
@@ -31,6 +31,10 @@ export class InoreaderCollection extends Collection {
         return super.cfg as InoreaderAccount;
     }
 
+    private get domain(): string {
+        return App.cfg.get<string>('inoreader-domain')!;
+    }
+
     async init() {
         const list_path = pathJoin(this.dir, 'feed_list');
         if (await fileExists(list_path)) {
@@ -67,7 +71,7 @@ export class InoreaderCollection extends Collection {
 
         const client_id = this.cfg.appid;
         const redirect_uri = encodeURIComponent(`http://127.0.0.1:${addr.port}`);
-        const url = `https://www.inoreader.com/oauth2/auth?client_id=${client_id}&redirect_uri=${redirect_uri}&response_type=code&scope=read+write&state=1`;
+        const url = `https://${this.domain}/oauth2/auth?client_id=${client_id}&redirect_uri=${redirect_uri}&response_type=code&scope=read+write&state=1`;
         await vscode.env.openExternal(vscode.Uri.parse(url));
 
         const auth_code = await vscode.window.withProgress({
@@ -99,7 +103,7 @@ export class InoreaderCollection extends Collection {
         }));
 
         const res = await got({
-            url: 'https://www.inoreader.com/oauth2/token',
+            url: `https://${this.domain}/oauth2/token`,
             method: 'POST',
             form: {
                 code: auth_code,
@@ -124,7 +128,7 @@ export class InoreaderCollection extends Collection {
 
     private async refreshToken(token: Token) {
         const res = await got({
-            url: 'https://www.inoreader.com/oauth2/token',
+            url: `https://${this.domain}/oauth2/token`,
             method: 'POST',
             form: {
                 client_id: this.cfg.appid,
@@ -164,7 +168,7 @@ export class InoreaderCollection extends Collection {
         const access_token = await this.getAccessToken();
 
         const res = await got({
-            url: `https://www.inoreader.com/reader/api/0/${cmd}`,
+            url: `https://${this.domain}/reader/api/0/${cmd}`,
             method: 'POST',
             headers: {'Authorization': `Bearer ${access_token}`},
             form: param,


### PR DESCRIPTION
The official domain of Inoreader is censored in China, and this patch allows users to configure an alternative available domain.